### PR TITLE
[WIP] Reimplement IORING_OP_SENDMSG_ZC

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -246,7 +246,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             int offset = iovArray.count();
 
             try {
-                in.forEachFlushedMessage(iovArray);
+                in.forEachFlushedMessage(filterWriteMultiple(iovArray));
             } catch (Exception e) {
                 // This should never happen, anyway fallback to single write.
                 return scheduleWriteSingle(in.current());
@@ -263,6 +263,10 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 return 0;
             }
             return 1;
+        }
+
+        protected ChannelOutboundBuffer.MessageProcessor filterWriteMultiple(IovArray iovArray) {
+           return iovArray;
         }
 
         @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -109,11 +109,10 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
             assert writeId == 0;
 
-            Object currentMsg = in.current();
             IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
             //at least one buffer in the batch exceeds `IO_URING_WRITE_ZERO_COPY_THRESHOLD`.
             if (IoUring.isSendmsgZcSupported()
-                    && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) currentMsg).readableBytes()))) {
+                    && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) in.current()).readableBytes()))) {
                 IoUringIoHandler handler = registration().attachment();
 
                 IovArray iovArray = handler.iovArray();
@@ -137,7 +136,7 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
                     });
                 } catch (Exception e) {
                     // This should never happen, anyway fallback to single write.
-                    return scheduleWriteSingle(currentMsg);
+                    return scheduleWriteSingle(in.current());
                 }
                 long iovArrayAddress = iovArray.memoryAddress(offset);
                 int iovArrayLength = iovArray.count() - offset;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -111,6 +111,7 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
 
             Object currentMsg = in.current();
             IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
+            //at least one buffer in the batch exceeds `IO_URING_WRITE_ZERO_COPY_THRESHOLD`.
             if (IoUring.isSendmsgZcSupported() && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) currentMsg).readableBytes()))) {
                 IoUringIoHandler handler = registration().attachment();
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -109,8 +109,9 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
             assert writeId == 0;
 
-            if (IoUring.isSendmsgZcSupported() && (
-                    (IoUringSocketChannelConfig) config()).shouldWriteZeroCopy((int) in.totalPendingWriteBytes())) {
+            Object currentMsg = in.current();
+            IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
+            if (IoUring.isSendmsgZcSupported() && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) currentMsg).readableBytes()))) {
                 IoUringIoHandler handler = registration().attachment();
 
                 IovArray iovArray = handler.iovArray();
@@ -119,10 +120,22 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
                 // buffers.
                 iovArray.maxCount(Native.MAX_SKB_FRAGS);
                 try {
-                    in.forEachFlushedMessage(iovArray);
+                    in.forEachFlushedMessage(new ChannelOutboundBuffer.MessageProcessor() {
+                        @Override
+                        public boolean processMessage(Object msg) throws Exception {
+                            if (msg instanceof ByteBuf) {
+                                ByteBuf buf = (ByteBuf) msg;
+                                int length = buf.readableBytes();
+                                if (ioUringSocketChannelConfig.shouldWriteZeroCopy(length)) {
+                                    return iovArray.processMessage(msg);
+                                }
+                            }
+                            return false;
+                        }
+                    });
                 } catch (Exception e) {
                     // This should never happen, anyway fallback to single write.
-                    return scheduleWriteSingle(in.current());
+                    return scheduleWriteSingle(currentMsg);
                 }
                 long iovArrayAddress = iovArray.memoryAddress(offset);
                 int iovArrayLength = iovArray.count() - offset;
@@ -142,6 +155,24 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
             }
             // Should not use sendmsg_zc, just use normal writev.
             return super.scheduleWriteMultiple(in);
+        }
+
+        @Override
+        protected ChannelOutboundBuffer.MessageProcessor filterWriteMultiple(IovArray iovArray) {
+            IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
+            return new ChannelOutboundBuffer.MessageProcessor() {
+                @Override
+                public boolean processMessage(Object msg) throws Exception {
+                    if (msg instanceof ByteBuf) {
+                        ByteBuf buf = (ByteBuf) msg;
+                        int length = buf.readableBytes();
+                        if (ioUringSocketChannelConfig.shouldWriteZeroCopy(length)) {
+                            return false;
+                        }
+                    }
+                    return iovArray.processMessage(msg);
+                }
+            };
         }
 
         @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -112,7 +112,8 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
             Object currentMsg = in.current();
             IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
             //at least one buffer in the batch exceeds `IO_URING_WRITE_ZERO_COPY_THRESHOLD`.
-            if (IoUring.isSendmsgZcSupported() && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) currentMsg).readableBytes()))) {
+            if (IoUring.isSendmsgZcSupported()
+                    && (ioUringSocketChannelConfig.shouldWriteZeroCopy(((ByteBuf) currentMsg).readableBytes()))) {
                 IoUringIoHandler handler = registration().attachment();
 
                 IovArray iovArray = handler.iovArray();


### PR DESCRIPTION
Motivation:

https://github.com/axboe/liburing/issues/1191

On HTTP workloads that send a large amount of data, we observe significant CPU time spent copying userspace buffers into kernel socket buffers. This makes zero-copy sends an attractive optimization.

However, this approach also slightly increases CPU usage for workloads that mainly send small buffers such as HTTP headers. In practice, every large data buffer is usually accompanied by one or more small header buffers, which also incur zero-copy related overhead.

Previously, the decision to use sendmsg_zc was based on the total pending write size, i.e.:

``` java
shouldWriteZeroCopy(in.totalPendingWriteBytes())
```

This means that as long as the aggregate size exceeded the zero-copy threshold, all buffers in the batch (including small headers) were included in the sendmsg_zc operation.

This limits the overall benefit of zero-copy, as in mixed-size buffer scenarios (e.g. headers combined with large payloads) we cannot fully realize the advantages of send_zc or sendmsg_zc.

Modification:

This change refines the behavior so that:
	•	sendmsg_zc is only used for multiple buffers that individually satisfy the zero-copy size threshold
	•	Buffers that do not meet the send_zc eligibility criteria are excluded from the zero-copy batch
	•	Small buffers (e.g. headers) are no longer forced through the zero-copy path simply because they are adjacent to large buffers

In other words, this change applies sendmsg_zc selectively, rather than batching buffers of mixed sizes indiscriminately.

Result:

Reimplement IORING_OP_SENDMSG_ZC
